### PR TITLE
Added Export Compliance Declaration

### DIFF
--- a/App/iOS/Info.plist
+++ b/App/iOS/Info.plist
@@ -20,6 +20,8 @@
 	<string>1.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>NSUserActivityTypes</key>

--- a/ci_scripts/ci_post_xcodebuild.sh
+++ b/ci_scripts/ci_post_xcodebuild.sh
@@ -9,7 +9,7 @@ then
     xcodebuild \
       -workspace "$CI_WORKSPACE/$CI_XCODE_PROJECT" \
       -scheme "iOS Production" \
-      -destination 'platform=iOS Simulator,name=iPhone 13' \
+      -destination 'platform=iOS Simulator,name=iPhone 11' \
       -enableCodeCoverage YES \
       -resultBundlePath $CI_RESULT_BUNDLE_PATH \
       test-without-building


### PR DESCRIPTION
Added Export Compliance Declaration for App Store to remove the need for TestFlight builds to be manually approved.